### PR TITLE
a couple of improvements for attachment performance and compatibility

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1675,10 +1675,17 @@ function Download()
 	{
 		if (strpos($_SERVER['HTTP_USER_AGENT'], 'Windows') !== false)
 			$callback = create_function('$buffer', 'return preg_replace(\'~[\r]?\n~\', "\r\n", $buffer);');
-		elseif (strpos($_SERVER['HTTP_USER_AGENT'], 'Mac') !== false)
-			$callback = create_function('$buffer', 'return preg_replace(\'~[\r]?\n~\', "\r", $buffer);');
+		// Mac OS X uses \n. It hasn't used \r since Mac OS 9.
+		// elseif (strpos($_SERVER['HTTP_USER_AGENT'], 'Mac') !== false)
+			// $callback = create_function('$buffer', 'return preg_replace(\'~[\r]?\n~\', "\r", $buffer);');
 		else
 			$callback = create_function('$buffer', 'return preg_replace(\'~[\r]?\n~\', "\n", $buffer);');
+	}
+
+	// If no reencoding needs to be done, send via X-Sendfile
+	if(!isset($callback) && !empty($modSettings['attachmentViaSendfile'])) {
+		header('X-Sendfile: ' . $filename);
+		obExit(false);
 	}
 
 	// Since we don't do output compression for files this large...

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -344,6 +344,7 @@ $txt['attachmentEnable'] = 'Attachments mode';
 $txt['attachmentEnable_deactivate'] = 'Disable attachments';
 $txt['attachmentEnable_enable_all'] = 'Enable all attachments';
 $txt['attachmentEnable_disable_new'] = 'Disable new attachments';
+$txt['attachmentViaSendfile'] = 'Send via <a href="http://blog.lighttpd.net/articles/2006/07/02/x-sendfile" target="_blank">X-Sendfile</a><div class="smalltext">(disabled when line endings are recoded)</div>';
 $txt['attachmentCheckExtensions'] = 'Check attachment\'s extension';
 $txt['attachmentExtensions'] = 'Allowed attachment extensions';
 $txt['attachmentRecodeLineEndings'] = 'Recode line endings in textual attachments';


### PR DESCRIPTION
(core) use X-Sendfile, if enabled
(core) Mac OS switched to \n ages ago
(core) simple caching for attachment dir size

tested on lighttpd only, but nginx and apache both support X-Sendfile if so configured. I used modSettings for caching here instead of the regular caching mechanism because it's just one measly integer value.
